### PR TITLE
fix clang/gcc-6 compile error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(Doxygen)
 find_package(BLAS)
 find_package(LAPACK)
 
-set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -Werror -pedantic -Wfatal-errors -std=c++1y")
+set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -Werror -Wextra -pedantic -Wfatal-errors -std=c++1y")
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
 
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include"

--- a/test/norms.cpp
+++ b/test/norms.cpp
@@ -17,8 +17,6 @@
 
 using namespace std;
 
-const double tol = 1e-04;
-
 template <typename Vector, typename Matrix>
 int
 zero_tests()
@@ -52,6 +50,7 @@ template <typename Vector, typename Matrix>
 int
 expr_tests()
 {
+    const double tol = 1e-04;
     const int n = 5;
     Vector one(n, 1.0);
 

--- a/test/test_utilities.hpp
+++ b/test/test_utilities.hpp
@@ -87,7 +87,7 @@ generate_vector(std::mt19937& rng,
 {
     Vector v(n);
     std::normal_distribution<> numsig(mean, sd);
-    auto rnorm = std::bind(numsig, std::ref(rng));
+    auto rnorm = [&rng, &numsig](){ return numsig(rng); };
     std::generate(v.begin(), v.end(), rnorm);
     return v;
 }


### PR DESCRIPTION
added -Wextra and fixed some compile errors. Not sure what was wrong with the std::bind solution in the first place, though.